### PR TITLE
Remove strings.Title() formatting from horoscope response

### DIFF
--- a/handlers/horoscopes/handlers.go
+++ b/handlers/horoscopes/handlers.go
@@ -105,14 +105,12 @@ func (h *Handler) GetHoroscope(w http.ResponseWriter, r *http.Request) {
 		err = json.Unmarshal([]byte(val), &result)
 	}
 
-	text := strings.Title(result.Horoscope)
-
 	response = models.SlackResponse{
 		ResponseType: "in_channel",
 		Text: result.Sunsign,
 		Attachments: []models.SlackResponseAttachment{
 			{
-				Text: text,
+				Text: result.Horoscope,
 			},
 		},
 	}


### PR DESCRIPTION
To prevent every word from the horoscope response being capitalized, the `strings.Title()` method is removed.